### PR TITLE
fix: ImageFilelist ignores root when reading flist path

### DIFF
--- a/data.py
+++ b/data.py
@@ -26,7 +26,7 @@ class ImageFilelist(data.Dataset):
     def __init__(self, root, flist, transform=None,
                  flist_reader=default_flist_reader, loader=default_loader):
         self.root = root
-        self.imlist = flist_reader(flist)
+        self.imlist = flist_reader(os.path.join(self.root, flist))
         self.transform = transform
         self.loader = loader
 


### PR DESCRIPTION
### Problem
fix: ImageFilelist ignores root when reading flist path

### Fix
Replace:
```
        self.root = root
        self.imlist = flist_reader(flist)
        self.transform = transform
```

with:
```
        self.root = root
        self.imlist = flist_reader(os.path.join(self.root, flist))
        self.transform = transform
```

### Files changed
- `data.py`