### PR TITLE
fix: val directory not created when train directory already exists

### DIFF
--- a/prepare-market.py
+++ b/prepare-market.py
@@ -97,6 +97,7 @@ train_save_path = download_path + '/pytorch/train'
 val_save_path = download_path + '/pytorch/val'
 if not os.path.isdir(train_save_path):
     os.mkdir(train_save_path)
+if not os.path.isdir(val_save_path):
     os.mkdir(val_save_path)
 
 for root, dirs, files in os.walk(train_path, topdown=True):


### PR DESCRIPTION
### Problem
fix: val directory not created when train directory already exists

### Fix
Replace:
```
if not os.path.isdir(train_save_path):
    os.mkdir(train_save_path)
    os.mkdir(val_save_path)
```

with:
```
if not os.path.isdir(train_save_path):
    os.mkdir(train_save_path)
if not os.path.isdir(val_save_path):
    os.mkdir(val_save_path)
```

### Files changed
- `prepare-market.py`