### PR TITLE
fix: RandomErasing reseeds global RNG on every instance

### DIFF
--- a/random_erasing.py
+++ b/random_erasing.py
@@ -31,7 +31,6 @@ class RandomErasing(object):
         self.sl = sl
         self.sh = sh
         self.r1 = r1
-        random.seed(7)
 
     def __call__(self, img):
 


### PR DESCRIPTION
### Problem
fix: RandomErasing reseeds global RNG on every instance

### Fix
Replace:
```
        self.sh = sh
        self.r1 = r1
        random.seed(7)
```

with:
```
        self.sh = sh
        self.r1 = r1
```

### Files changed
- `random_erasing.py`