### PR TITLE
fix: --resume argument is ignored and output directory is always wiped

### DIFF
--- a/train.py
+++ b/train.py
@@ -78,7 +78,7 @@ train_writer = tensorboardX.SummaryWriter(os.path.join(opts.output_path + "/logs
 output_directory = os.path.join(opts.output_path + "/outputs", model_name)
 if not os.path.exists(output_directory):
     os.makedirs(output_directory)
-else:
+elif not opts.resume:
     shutil.rmtree(output_directory)
     os.makedirs(output_directory)
 shutil.copyfile(opts.config, os.path.join(output_directory, 'config.yaml')) # copy config file to output folder


### PR DESCRIPTION
### Problem
fix: --resume argument is ignored and output directory is always wiped

### Fix
Replace:
```
output_directory = os.path.join(opts.output_path + "/outputs", model_name)
if not os.path.exists(output_directory):
    os.makedirs(output_directory)
else:
    shutil.rmtree(output_directory)
    os.makedirs(output_directory)
```

with:
```
output_directory = os.path.join(opts.output_path + "/outputs", model_name)
if not os.path.exists(output_directory):
    os.makedirs(output_directory)
elif not opts.resume:
    shutil.rmtree(output_directory)
    os.makedirs(output_directory)
```

### Files changed
- `train.py`